### PR TITLE
Upgrade to client v4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>io.orkes.conductor</groupId>
 			<artifactId>orkes-conductor-client-spring</artifactId>
-			<version>4.0.0</version>
+			<version>4.0.1</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/io/orkes/demo/banking/BankingApplication.java
+++ b/src/main/java/io/orkes/demo/banking/BankingApplication.java
@@ -6,11 +6,9 @@ import lombok.AllArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 
 @AllArgsConstructor
 @SpringBootApplication
-@ComponentScan(basePackages = {"io.orkes", "com.netflix.conductor"})
 public class BankingApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
- Upgrade to client `v4.0.1`.
- Remove unnecessary `@ComponentScan` annotation. With latest changes, this is not required. The client and workers will be started if the proper configuration is set up in `application.properties`.